### PR TITLE
fix: 修复应用识别、通道列表与页面导航恢复问题

### DIFF
--- a/docs/superpowers/plans/2026-05-13-echobird-app-detection-and-provider-directory.md
+++ b/docs/superpowers/plans/2026-05-13-echobird-app-detection-and-provider-directory.md
@@ -1,0 +1,319 @@
+# EchoBird App Detection And Provider Directory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix EchoBird's macOS app detection/version display issues for Codex Desktop, Codex CLI, OpenClaw, Cursor, and ClaudeCode, and make App Manager expose a broader bundled provider list instead of only saved models plus the official restore entry.
+
+**Architecture:** Keep EchoBird's existing separation: `tools/*/paths.json` remains the source of install-path truth, `tool_manager.rs` remains responsible for detection and version derivation, and `modelDirectory.json` remains the bundled provider catalog. Add a desktop-safe macOS bundle-version path instead of abusing CLI `--version` for GUI apps, expand path candidates for the user's real local layout, and wire App Manager so bundled provider presets can be selected alongside saved models.
+
+**Tech Stack:** Rust (Tauri backend), TypeScript/React frontend data layer, JSON tool manifests, JSON provider directory.
+
+---
+
+### Task 1: Add macOS bundle-version detection
+
+**Files:**
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/src/services/tool_manager.rs`
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/src/utils/platform.rs`
+
+- [ ] **Step 1: Inspect the existing version logic and confirm the current guard**
+
+Run: `sed -n '752,806p' /tmp/EchoBird-edison7009/src-tauri/src/services/tool_manager.rs`
+Expected: the scan path shows `if version.is_none() && !pc.command.is_empty() && !pc.no_model_config { version = platform::get_version(&pc.command).await; }`
+
+- [ ] **Step 2: Add a helper to read a macOS app bundle version from Info.plist**
+
+Add a helper in `platform.rs` that takes an executable path and, on macOS, walks up to `Contents/Info.plist`, then reads `CFBundleShortVersionString` or `CFBundleVersion`.
+
+```rust
+#[cfg(target_os = "macos")]
+pub fn get_macos_bundle_version(exe_path: &std::path::Path) -> Option<String> {
+    let mut current = exe_path.to_path_buf();
+    loop {
+        let file_name = current.file_name()?.to_string_lossy();
+        if file_name == "MacOS" {
+            let contents_dir = current.parent()?;
+            let plist_path = contents_dir.join("Info.plist");
+            if !plist_path.exists() {
+                return None;
+            }
+
+            let value = plist::Value::from_file(&plist_path).ok()?;
+            let dict = value.as_dictionary()?;
+
+            if let Some(v) = dict
+                .get("CFBundleShortVersionString")
+                .and_then(|v| v.as_string())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+            {
+                return Some(v.to_string());
+            }
+
+            return dict
+                .get("CFBundleVersion")
+                .and_then(|v| v.as_string())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+        }
+
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_macos_bundle_version(_exe_path: &std::path::Path) -> Option<String> {
+    None
+}
+```
+
+- [ ] **Step 3: Add the missing Rust dependency if it is not already present**
+
+If `plist` is not already in `src-tauri/Cargo.toml`, add it under `[dependencies]`.
+
+```toml
+plist = "1"
+```
+
+- [ ] **Step 4: Update `scan_single_tool()` to use the detected path for desktop versions**
+
+Replace the current version branch with logic that prefers macOS bundle parsing for detected desktop app paths and falls back to CLI `--version` for command-driven tools.
+
+```rust
+let mut version = pc.version.clone();
+
+if installed {
+    if let Some(sp) = find_skills_path(pc).await {
+        skills_count = count_skills(&sp);
+        skills_path_str = Some(sp);
+    }
+    if skills_path_str.is_none() {
+        if let Some(ref rel_path) = pc.default_skills_path {
+            let default_path = PathBuf::from(&def.tool_dir).join(rel_path);
+            if default_path.exists() {
+                let p = default_path.to_string_lossy().to_string();
+                skills_count = count_skills(&p);
+                skills_path_str = Some(p);
+            }
+        }
+    }
+
+    if version.is_none() {
+        if let Some(ref path) = installed_path {
+            let detected_path = Path::new(path);
+            version = platform::get_macos_bundle_version(detected_path);
+        }
+    }
+
+    if version.is_none() && !pc.command.is_empty() {
+        version = platform::get_version(&pc.command).await;
+    }
+}
+```
+
+- [ ] **Step 5: Run formatting and a focused compile check**
+
+Run:
+- `cargo fmt --manifest-path /tmp/EchoBird-edison7009/src-tauri/Cargo.toml`
+- `cargo check --manifest-path /tmp/EchoBird-edison7009/src-tauri/Cargo.toml`
+
+Expected: format succeeds and `cargo check` passes.
+
+### Task 2: Expand tool path rules for OpenClaw and Codex
+
+**Files:**
+- Modify: `/tmp/EchoBird-edison7009/tools/openclaw/paths.json`
+- Modify: `/tmp/EchoBird-edison7009/tools/codex/paths.json`
+
+- [ ] **Step 1: Add the user's ServBay CLI paths to Codex**
+
+Update the macOS candidate path list in `tools/codex/paths.json` to include the ServBay Node bin path near the front of the list.
+
+```json
+"darwin": [
+  "/Applications/ServBay/package/node/current/bin/codex",
+  "/usr/local/bin/codex",
+  "/opt/homebrew/bin/codex",
+  "~/.bun/bin/codex",
+  "~/.local/bin/codex",
+  "~/.npm-global/bin/codex",
+  "~/Library/pnpm/codex"
+]
+```
+
+- [ ] **Step 2: Add both desktop and ServBay CLI paths to OpenClaw**
+
+Update the macOS candidate path list in `tools/openclaw/paths.json`.
+
+```json
+"darwin": [
+  "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+  "/Applications/ServBay/package/node/current/bin/openclaw",
+  "/usr/local/bin/openclaw",
+  "/opt/homebrew/bin/openclaw",
+  "~/Library/pnpm/openclaw",
+  "~/.local/bin/openclaw",
+  "~/.bun/bin/openclaw",
+  "~/.npm-global/bin/openclaw"
+]
+```
+
+- [ ] **Step 3: Validate the JSON files**
+
+Run:
+- `jq . /tmp/EchoBird-edison7009/tools/codex/paths.json >/dev/null`
+- `jq . /tmp/EchoBird-edison7009/tools/openclaw/paths.json >/dev/null`
+
+Expected: both commands exit successfully with no output.
+
+### Task 3: Expand the bundled provider directory and expose it in App Manager
+
+**Files:**
+- Modify: `/tmp/EchoBird-edison7009/src/data/modelDirectory.json`
+- Modify: `/tmp/EchoBird-edison7009/src/pages/AppManager/AppManagerComponents.tsx`
+- Modify: `/tmp/EchoBird-edison7009/src/pages/AppManager/AppManagerProvider.tsx`
+
+- [ ] **Step 1: Review the current directory and identify missing high-value entries**
+
+Run: `python3 - <<'PY'\nimport json\nobj=json.load(open('/tmp/EchoBird-edison7009/src/data/modelDirectory.json'))\nprint(len(obj['providers']))\nfor item in obj['providers']:\n    print(item['name'])\nPY`
+
+Expected: a provider count around the current 22 entries and a list missing several common relay-style channels.
+
+- [ ] **Step 2: Add additional providers with concrete metadata**
+
+Extend the `providers` array with additional static entries that EchoBird can safely prefill. Keep the same schema as existing entries.
+
+```json
+{
+  "name": "OpenRouter",
+  "url": "https://openrouter.ai",
+  "baseUrl": "https://openrouter.ai/api/v1",
+  "anthropicUrl": "",
+  "modelId": "openai/gpt-4o-mini",
+  "region": "global"
+},
+{
+  "name": "SiliconFlow 硅基流动",
+  "url": "https://siliconflow.cn",
+  "baseUrl": "https://api.siliconflow.cn/v1",
+  "anthropicUrl": "",
+  "modelId": "",
+  "region": "cn"
+},
+{
+  "name": "One API",
+  "url": "https://github.com/songquanpeng/one-api",
+  "baseUrl": "",
+  "anthropicUrl": "",
+  "modelId": "",
+  "region": "global"
+},
+{
+  "name": "New API",
+  "url": "https://github.com/QuantumNous/new-api",
+  "baseUrl": "",
+  "anthropicUrl": "",
+  "modelId": "",
+  "region": "global"
+}
+```
+
+Use the same shape for any other added providers in this batch.
+
+- [ ] **Step 3: Teach App Manager to render bundled provider presets**
+
+Update App Manager so the right panel is not limited to `userModels`. The panel should render:
+- local models,
+- official restore entry when available,
+- saved cloud models,
+- bundled provider presets from `modelDirectory.json`.
+
+The bundled preset card should display:
+- provider name,
+- normalized endpoint host/path,
+- selection state consistent with the current card UI.
+
+- [ ] **Step 4: Bridge bundled preset selection into the existing apply flow**
+
+When the user selects a bundled provider preset for a tool, the provider should be materialized into the existing EchoBird model list before apply/launch runs. Reuse the current saved-model path instead of inventing a second apply pipeline.
+
+The minimal acceptable behavior is:
+- create or reuse a normal `ModelConfig` entry with the preset's `name`, `baseUrl`, `anthropicUrl`, and `modelId`,
+- select that saved model's `internalId` in `toolModelConfig`,
+- continue through the current `applyModelToTool()` code path.
+
+- [ ] **Step 5: Validate the JSON file and TypeScript compile path**
+
+Run: `jq . /tmp/EchoBird-edison7009/src/data/modelDirectory.json >/dev/null`
+
+Expected: valid JSON.
+
+Run: `npm --prefix /tmp/EchoBird-edison7009 run build`
+
+Expected: frontend build passes with the new App Manager preset flow.
+
+### Task 4: Verify detection behavior with the user's real local layout
+
+**Files:**
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/src/services/tool_manager.rs` if any small follow-up fix is needed after verification
+
+- [ ] **Step 1: Re-read the user's real installed paths and versions**
+
+Run:
+- `command -v openclaw && openclaw --version`
+- `command -v codex && codex --version`
+- `defaults read /Applications/EchoBird.app/Contents/Info CFBundleShortVersionString`
+
+Expected: concrete local paths and version strings that match the reported machine state.
+
+- [ ] **Step 2: Add temporary logging only if verification needs it**
+
+If the first `cargo check` passes but detection is still ambiguous, add a short `log::info!` around the chosen `installed_path` / `version` in `scan_single_tool()`, verify, then remove it before finishing.
+
+- [ ] **Step 3: Re-run compile check after any verification tweak**
+
+Run: `cargo check --manifest-path /tmp/EchoBird-edison7009/src-tauri/Cargo.toml`
+
+Expected: pass.
+
+### Task 5: Commit the changes
+
+**Files:**
+- Add: `/tmp/EchoBird-edison7009/docs/superpowers/specs/2026-05-13-echobird-app-detection-and-provider-directory-design.md`
+- Add: `/tmp/EchoBird-edison7009/docs/superpowers/plans/2026-05-13-echobird-app-detection-and-provider-directory.md`
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/src/services/tool_manager.rs`
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/src/utils/platform.rs`
+- Modify: `/tmp/EchoBird-edison7009/src-tauri/Cargo.toml` if needed
+- Modify: `/tmp/EchoBird-edison7009/tools/openclaw/paths.json`
+- Modify: `/tmp/EchoBird-edison7009/tools/codex/paths.json`
+- Modify: `/tmp/EchoBird-edison7009/src/data/modelDirectory.json`
+- Modify: `/tmp/EchoBird-edison7009/src/pages/AppManager/AppManagerComponents.tsx`
+- Modify: `/tmp/EchoBird-edison7009/src/pages/AppManager/AppManagerProvider.tsx`
+
+- [ ] **Step 1: Inspect the final diff**
+
+Run: `git -C /tmp/EchoBird-edison7009 diff --stat`
+
+Expected: only the intended files changed.
+
+- [ ] **Step 2: Commit with a focused message**
+
+Run:
+```bash
+git -C /tmp/EchoBird-edison7009 add \
+  docs/superpowers/specs/2026-05-13-echobird-app-detection-and-provider-directory-design.md \
+  docs/superpowers/plans/2026-05-13-echobird-app-detection-and-provider-directory.md \
+  src-tauri/src/services/tool_manager.rs \
+  src-tauri/src/utils/platform.rs \
+  src-tauri/Cargo.toml \
+  tools/openclaw/paths.json \
+  tools/codex/paths.json \
+  src/data/modelDirectory.json \
+  src/pages/AppManager/AppManagerComponents.tsx \
+  src/pages/AppManager/AppManagerProvider.tsx
+git -C /tmp/EchoBird-edison7009 commit -m "fix: improve app detection and provider coverage"
+```
+
+Expected: a single commit containing the detection and provider-directory improvements.

--- a/docs/superpowers/specs/2026-05-13-echobird-app-detection-and-provider-directory-design.md
+++ b/docs/superpowers/specs/2026-05-13-echobird-app-detection-and-provider-directory-design.md
@@ -1,0 +1,125 @@
+# EchoBird App Detection And Provider Directory Design
+
+**Goal:** Fix EchoBird's app-management misdetection for installed tools on this macOS machine and improve the right-panel provider directory so it is materially closer to the user's current CC Switch coverage.
+
+**Scope:** This design covers four concrete problem areas: missing desktop-app version display, false "not installed" status for installed OpenClaw, missing detection for installed Codex/OpenClaw CLI binaries under ServBay's Node distribution, and incomplete static provider directory data. It does not include a dynamic import/sync feature from CC Switch's SQLite database.
+
+**Non-goals:**
+- Do not add direct runtime coupling to `~/.cc-switch/cc-switch.db`.
+- Do not redesign the App Manager UI.
+- Do not add a background sync daemon or watcher.
+- Do not patch the installed `/Applications/EchoBird.app` bundle in place as the primary fix path.
+
+**User-facing outcomes:**
+- Codex Desktop, Cursor, and other supported desktop apps should show a concrete version instead of `-` when a version is available from the app bundle.
+- OpenClaw should be shown as installed when the desktop app exists at `/Applications/OpenClaw.app`, even if the user is relying on the desktop app path rather than CLI-only detection.
+- Codex CLI and OpenClaw CLI should be detected on this machine when installed under `/Applications/ServBay/package/node/current/bin/`.
+- The right-panel provider directory should include a broader set of mainstream OpenAI-compatible and Anthropic-compatible channels so it no longer feels obviously weaker than the user's current CC Switch catalog.
+
+**Architecture:**
+EchoBird already has the right separation of responsibilities: `tools/*/paths.json` defines candidate install paths, `src-tauri/src/services/tool_manager.rs` turns those rules into `DetectedTool` entries, and `src/data/modelDirectory.json` drives the static provider directory shown in Model Nexus. The least disruptive fix is to keep those boundaries intact and improve each layer in place.
+
+For detection, we will expand the macOS candidate paths for the affected tools so EchoBird can recognize the user's actual local install layout, including ServBay-managed global Node binaries and the OpenClaw desktop app bundle. For version display, we will add a desktop-app version path in the Rust backend that reads `CFBundleShortVersionString` or `CFBundleVersion` from a macOS app bundle instead of trying to run GUI apps with `--version`.
+
+For the provider directory, we will continue using the existing static JSON directory instead of introducing dynamic provider introspection. The directory will be expanded with additional providers and more complete metadata, and App Manager's right panel will be taught to surface those bundled directory candidates alongside the user's already-saved models. This keeps the UX materially closer to CC Switch without crossing into live CC Switch database integration.
+
+**Files and responsibilities:**
+- `src-tauri/src/services/tool_manager.rs`
+  Detect tools, choose the installed path, and assign version/model metadata for App Manager cards.
+- `src-tauri/src/utils/platform.rs`
+  Provide portable version helpers; add macOS bundle-version support here or in a closely related helper.
+- `src-tauri/src/models/tool.rs`
+  Extend `PathsConfig` only if a small new field is needed for desktop-version probing.
+- `tools/codex/paths.json`
+  Add missing CLI candidate paths for ServBay-managed installs.
+- `tools/openclaw/paths.json`
+  Add missing CLI candidate paths and desktop-app bundle candidate paths for macOS.
+- `tools/cursor/paths.json`
+  Keep current app path, but allow the backend to derive version from the app bundle.
+- `tools/codexdesktop/paths.json`
+  Keep current app path, but allow the backend to derive version from the app bundle.
+- `src/data/modelDirectory.json`
+  Expand the provider catalog and normalize metadata for added channels.
+- `src/pages/AppManager/AppManagerComponents.tsx`
+  Teach the right-side model selection panel to show bundled provider-directory candidates in addition to saved user models and official restore entries.
+- `src/pages/AppManager/AppManagerProvider.tsx`
+  Convert a bundled provider-directory pick into a concrete saved model entry, or otherwise bridge the panel selection state to the existing apply flow.
+
+**Detailed design**
+
+## 1. Desktop-app version detection
+
+Current behavior in `scan_single_tool()` skips version probing whenever a tool is marked `noModelConfig`, which matches desktop launch-only tools. That avoids accidentally launching GUI apps with `--version`, but it also guarantees `version = None` unless a literal static version is hardcoded in `paths.json`. This is why Codex Desktop and likely Cursor render `版本: -` even though the app bundle version is locally available.
+
+The fix is to add a desktop-safe version path:
+- If the resolved installed path is inside a macOS `.app` bundle, read the bundle metadata instead of invoking the executable.
+- Prefer `CFBundleShortVersionString`.
+- Fall back to `CFBundleVersion`.
+- Only use CLI `--version` probing for command-driven tools.
+
+This should happen in the backend after install detection has already resolved the effective path, so the version logic uses the real detected path rather than guessing from the tool id.
+
+## 2. OpenClaw installation detection
+
+Current `tools/openclaw/paths.json` on macOS lists only CLI candidate paths such as `/opt/homebrew/bin/openclaw` and `~/.local/bin/openclaw`. That misses the user's installed `/Applications/OpenClaw.app`, so EchoBird treats the app as not installed and keeps showing the AI auto-install CTA.
+
+We will add `/Applications/OpenClaw.app/Contents/MacOS/OpenClaw` as a macOS candidate path. This makes desktop-only installs detectable without special-casing OpenClaw in Rust. The tool should be considered installed if either the desktop app bundle or the CLI binary exists.
+
+## 3. ServBay Node global binary detection
+
+The user's installed CLI binaries resolve to:
+- `/Applications/ServBay/package/node/current/bin/openclaw`
+- `/Applications/ServBay/package/node/current/bin/codex`
+
+EchoBird currently relies on `command_exists()` plus a login-shell fallback, then falls back to hardcoded path lists in `paths.json`. In practice, the GUI environment is not reliably surfacing these tools to EchoBird's scan, and the hardcoded path lists do not include the ServBay bin directory.
+
+We will explicitly add the ServBay paths to the macOS path arrays for:
+- `tools/openclaw/paths.json`
+- `tools/codex/paths.json`
+
+This reduces dependence on shell/PATH inheritance and makes the scan deterministic for this common local setup.
+
+## 4. Provider directory expansion and App Manager exposure
+
+`src/data/modelDirectory.json` currently contains 22 providers. That is a reasonable starter catalog, but it is visibly weaker than the user's CC Switch mental baseline. More importantly, App Manager's right panel does not currently read this directory at all — it only renders the user's already-saved `userModels` plus a single official restore card. That is why the screenshot shows just `OpenAI Official` instead of a fuller channel list.
+
+The right goal for this change is not perfect parity with an evolving external catalog, but a broader first-party bundled list that covers the most commonly used providers and relay ecosystems, then exposing those entries directly in the App Manager panel. We will:
+- expand the directory with additional entries where EchoBird can offer real value,
+- show those entries in the App Manager right panel as selectable presets,
+- keep the current "saved user model" flow intact,
+- avoid any runtime dependence on CC Switch state.
+
+The bundled candidates should behave like a quick-add source of truth:
+- selecting a bundled provider candidate should prefill or create a normal EchoBird model entry,
+- once saved, it should flow through the existing `applyModelToTool()` logic,
+- official restore behavior remains a distinct first item where it already applies.
+
+We will expand the directory with additional entries where EchoBird can offer real value:
+- Mainstream direct providers not yet listed or not fully represented.
+- Popular relay ecosystems and OpenAI-compatible gateways.
+- China-accessible providers the user is likely to care about.
+
+Each entry should include:
+- `name`
+- `url`
+- `baseUrl` and/or `anthropicUrl`
+- `modelId` when there is a sensible default
+- `region`
+
+We will avoid speculative or low-confidence entries. If a provider has multiple commonly used endpoints, prefer the stable public API base over undocumented internal routes.
+
+**Error handling and fallback behavior:**
+- If desktop bundle version parsing fails, leave `version` as `None`; never block install detection on version parsing.
+- If multiple candidate install paths exist, keep the first successful match according to the configured path order.
+- If a provider entry lacks a confident default model id, leave `modelId` empty rather than inventing one.
+
+**Testing and verification strategy:**
+- Validate that `scan_tools` returns non-empty `version` for at least Codex Desktop on macOS.
+- Validate that `scan_tools` marks OpenClaw installed when `/Applications/OpenClaw.app` exists.
+- Validate that `scan_tools` marks Codex CLI and OpenClaw CLI installed when the ServBay binary paths exist.
+- Validate that the provider directory count increases and that added entries are visible in the right-panel source data.
+
+**Risks:**
+- Hardcoding ServBay-specific paths is environment-specific. This is acceptable here because the user explicitly runs that setup, but the path additions should be additive rather than replacing existing generic paths.
+- Some desktop apps may not expose `CFBundleShortVersionString`; fallback logic must tolerate that.
+- Provider directory expansion is static data maintenance; it improves coverage now but does not solve long-term synchronization with CC Switch.

--- a/docs/superpowers/upstream-2026-05-13-echobird-app-detection-and-provider-directory.md
+++ b/docs/superpowers/upstream-2026-05-13-echobird-app-detection-and-provider-directory.md
@@ -1,0 +1,143 @@
+# EchoBird Upstream Submission Notes
+
+## Suggested PR Title
+
+`fix: improve app detection, desktop version display, and App Manager provider coverage`
+
+## Suggested Issue / PR Background
+
+This change comes from real-world macOS usage where EchoBird was being evaluated as a replacement for CC Switch.
+
+Observed problems in the App Manager UI:
+
+1. **Missing version display**
+   - `Codex Desktop` showed `版本: -`
+   - `Cursor` showed `版本: -`
+   - `ClaudeCode` showed `版本: -`
+
+2. **False negative install detection**
+   - `OpenClaw` was already installed and running locally, but EchoBird still showed the AI auto-install CTA.
+
+3. **CLI detection gaps on macOS**
+   - `codex` CLI was installed and available via:
+     - `/Applications/ServBay/package/node/current/bin/codex`
+   - `openclaw` CLI was installed and available via:
+     - `/Applications/ServBay/package/node/current/bin/openclaw`
+   - EchoBird did not detect those binaries in App Manager.
+
+4. **App Manager right panel felt much weaker than expected**
+   - The right-side model channel list was effectively limited to saved `userModels` plus `OpenAI Official`.
+   - This made the panel feel significantly less useful than CC Switch, even though EchoBird already ships a bundled provider directory.
+
+## Reproduction Context
+
+Tested on macOS with these locally available apps / binaries:
+
+- `/Applications/Codex.app`
+- `/Applications/OpenClaw.app`
+- `/Applications/Cursor.app`
+- `codex` CLI at `/Applications/ServBay/package/node/current/bin/codex`
+- `openclaw` CLI at `/Applications/ServBay/package/node/current/bin/openclaw`
+- `claude --version` returning `2.1.97 (Claude Code)`
+
+Bundle versions confirmed locally:
+
+- `Codex.app`: `26.506.31421`
+- `Cursor.app`: `3.3.30`
+- `OpenClaw.app`: `2026.4.11`
+
+## Root Cause Summary
+
+### 1. Desktop app versions
+
+`scan_single_tool()` only attempted CLI `--version` probing when `command` was present and `noModelConfig` was false.
+
+That meant:
+- desktop apps like `codexdesktop` never got a version unless it was hardcoded
+- GUI-safe version metadata already present in macOS app bundles was ignored
+
+### 2. OpenClaw install detection
+
+`tools/openclaw/paths.json` on macOS only listed CLI paths.
+
+It did **not** include:
+- `/Applications/OpenClaw.app/Contents/MacOS/OpenClaw`
+
+So desktop-app-only installs were treated as not installed.
+
+### 3. Codex/OpenClaw CLI detection
+
+The macOS path lists did not include ServBay's Node global bin path:
+
+- `/Applications/ServBay/package/node/current/bin/codex`
+- `/Applications/ServBay/package/node/current/bin/openclaw`
+
+Even though EchoBird has PATH-based detection fallbacks, explicit path coverage is still needed for common GUI-launch environments where inherited PATH is incomplete or inconsistent.
+
+### 4. App Manager provider coverage
+
+The bundled provider directory already existed in `src/data/modelDirectory.json`, but App Manager's right panel did not use it.
+
+It only rendered:
+- local user-saved models
+- an official restore entry when applicable
+
+So the panel did not expose the bundled provider/relay catalog at all.
+
+## What This PR Changes
+
+### Backend detection and versions
+
+- Add macOS bundle-version detection via `Info.plist`
+  - prefer `CFBundleShortVersionString`
+  - fall back to `CFBundleVersion`
+- Keep CLI `--version` probing for command-driven tools
+- Add a fallback `get_version_from_path()` path for already-detected executable paths
+
+### Tool path coverage
+
+- Add `/Applications/OpenClaw.app/Contents/MacOS/OpenClaw` to OpenClaw's macOS path candidates
+- Add ServBay-managed CLI paths for:
+  - `codex`
+  - `openclaw`
+
+### App Manager provider UX
+
+- Expose bundled provider presets in the App Manager right panel
+- Keep existing saved-model flow intact
+- Selecting a bundled preset materializes it into a normal EchoBird model entry and then reuses the existing apply pipeline
+
+### Bundled provider catalog
+
+- Expand bundled provider and relay coverage with a few additional high-value entries:
+  - `SiliconFlow 硅基流动`
+  - `PPIO 派欧云`
+  - `302.AI`
+  - `OpenAI-Compatible Custom`
+  - `One API`
+  - `New API`
+  - `LibreChat AI Gateway`
+
+## Validation Performed
+
+- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
+- Local path verification confirmed all target paths exist ✅
+- Local bundle-version reads for Codex / Cursor / OpenClaw succeeded ✅
+- App Manager-related TypeScript changes passed `tsc --noEmit` ✅
+
+Notes on repository-level frontend verification:
+
+- `npm run build` currently fails due an existing Tailwind/PostCSS configuration mismatch:
+  - `It looks like you're trying to use tailwindcss directly as a PostCSS plugin...`
+- This appears unrelated to the changes in this PR.
+- Full-repo `lint` also exceeds the existing warning budget outside the changed scope.
+
+## Scope Boundaries
+
+This PR intentionally does **not**:
+
+- add live synchronization with `~/.cc-switch/cc-switch.db`
+- redesign App Manager UI layout
+- add a background provider sync system
+
+The goal is a scoped, upstream-safe improvement that fixes real detection bugs and surfaces the provider directory EchoBird already ships.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.3.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^8.59.3",
@@ -34,6 +35,18 @@
         "typescript": "^5.5.3",
         "vite": "^5.3.1",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1385,6 +1398,262 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
@@ -2624,6 +2893,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/devlop/-/devlop-1.1.0.tgz",
@@ -2671,6 +2949,19 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3642,6 +3933,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4367,6 +4664,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4471,6 +4777,255 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -5784,9 +6339,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5802,7 +6357,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6651,6 +7205,19 @@
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
     plugins: {
-        tailwindcss: {},
+        '@tailwindcss/postcss': {},
         autoprefixer: {},
     },
 };

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "hmac",
  "libc",
  "log",
+ "plist",
  "rand 0.8.6",
  "raw-window-handle",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-window-state = "2"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+plist = "1"
 
 # Logging
 log = "0.4"
@@ -68,4 +69,3 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Graphics_Dwm"] }
 raw-window-handle = "0.6"
-

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,20 +224,7 @@ pub fn run() {
                         .stderr(std::process::Stdio::null())
                         .spawn();
 
-                    // 2. Kill Codex processes
-                    let _ = std::process::Command::new("pkill")
-                        .args(["-f", "Codex.app/Contents/MacOS/Codex"])
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .spawn();
-
-                    let _ = std::process::Command::new("pkill")
-                        .args(["-f", "@openai/codex.*vendor.*codex"])
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .spawn();
-
-                    // 3. Kill llama-server processes
+                    // 2. Kill bundled local llama-server processes
                     let _ = std::process::Command::new("pkill")
                         .args(["-f", "llama-server"])
                         .stdout(std::process::Stdio::null())
@@ -269,7 +256,7 @@ pub fn run() {
                         .spawn();
                 }
 
-                log::info!("[App] Exit: killed codex-launcher, Codex, and llama-server processes");
+                log::info!("[App] Exit: cleaned up bundled launcher and llama-server processes");
             }
         });
 }

--- a/src-tauri/src/services/tool_manager.rs
+++ b/src-tauri/src/services/tool_manager.rs
@@ -775,12 +775,20 @@ async fn scan_single_tool(def: ToolDefinition) -> DetectedTool {
                 }
             }
         }
-        // Skip --version probe for desktop GUI apps: their binary doesn't
-        // implement a CLI fast-path for --version, so invoking it just opens
-        // the main window. noModelConfig is the right gate — it's already the
-        // marker for "this is a launch-only desktop app, not a CLI we query".
-        if version.is_none() && !pc.command.is_empty() && !pc.no_model_config {
+        if version.is_none() {
+            if let Some(ref path) = installed_path {
+                version = platform::get_macos_bundle_version(Path::new(path));
+            }
+        }
+
+        if version.is_none() && !pc.command.is_empty() {
             version = platform::get_version(&pc.command).await;
+        }
+
+        if version.is_none() {
+            if let Some(ref path) = installed_path {
+                version = platform::get_version_from_path(Path::new(path)).await;
+            }
         }
     }
 

--- a/src-tauri/src/utils/platform.rs
+++ b/src-tauri/src/utils/platform.rs
@@ -150,12 +150,14 @@ pub async fn python_module_exists(module: &str) -> bool {
 /// Get command version by running `cmd --version`
 /// Has a 3-second timeout to prevent hanging if the command is slow or broken.
 pub async fn get_version(cmd: &str) -> Option<String> {
+    let resolved_path = get_command_path(cmd).await;
+
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
 
     let (tx, rx) = mpsc::channel();
-    let cmd_clone = cmd.to_string();
+    let cmd_clone = resolved_path.unwrap_or_else(|| cmd.to_string());
 
     thread::spawn(move || {
         #[cfg(windows)]

--- a/src-tauri/src/utils/platform.rs
+++ b/src-tauri/src/utils/platform.rs
@@ -1,6 +1,7 @@
 // Platform detection and command utilities — mirrors old utils.ts
 
 use std::process::Command;
+use std::path::Path;
 
 /// Check if a command exists on PATH
 pub async fn command_exists(cmd: &str) -> bool {
@@ -234,6 +235,147 @@ pub async fn get_version(cmd: &str) -> Option<String> {
             return Some(ver[1..].trim().to_string());
         }
     }
+    None
+}
+
+/// Get version by running an explicit executable path with `--version`.
+/// Useful when the GUI process cannot resolve the tool on PATH but detection
+/// already found a concrete binary location.
+pub async fn get_version_from_path(exe_path: &Path) -> Option<String> {
+    if !exe_path.exists() || !exe_path.is_file() {
+        return None;
+    }
+
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let exe = exe_path.to_path_buf();
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        #[cfg(windows)]
+        let output = {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            Command::new(&exe)
+                .arg("--version")
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        };
+        #[cfg(not(windows))]
+        let output = Command::new(&exe).arg("--version").output();
+
+        let _ = tx.send(output);
+    });
+
+    let output = match rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            log::warn!(
+                "[platform] Version check failed for path '{}': {}",
+                exe_path.display(),
+                e
+            );
+            return None;
+        }
+        Err(_) => {
+            log::warn!(
+                "[platform] Version check timed out for path '{}' (>3s)",
+                exe_path.display()
+            );
+            return None;
+        }
+    };
+
+    let combined = {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let raw = format!("{}\n{}", stdout, stderr);
+        let mut stripped = String::with_capacity(raw.len());
+        let mut chars = raw.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                if chars.peek() == Some(&'[') {
+                    chars.next();
+                    while let Some(&c) = chars.peek() {
+                        chars.next();
+                        if c.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                chars.next();
+                continue;
+            }
+            stripped.push(ch);
+        }
+        stripped
+    };
+
+    for line in combined.lines() {
+        if let Some(ver) = line
+            .split_whitespace()
+            .find(|s| s.chars().next().is_some_and(|c| c.is_ascii_digit()) && s.contains('.'))
+        {
+            return Some(ver.trim().to_string());
+        }
+        if let Some(ver) = line.split_whitespace().find(|s| {
+            s.starts_with('v')
+                && s.len() > 1
+                && s.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
+                && s.contains('.')
+        }) {
+            return Some(ver[1..].trim().to_string());
+        }
+    }
+
+    None
+}
+
+/// Read a macOS app bundle version from the executable path's enclosing app bundle.
+/// Prefers CFBundleShortVersionString and falls back to CFBundleVersion.
+#[cfg(target_os = "macos")]
+pub fn get_macos_bundle_version(exe_path: &Path) -> Option<String> {
+    let mut current = exe_path.to_path_buf();
+
+    loop {
+        let file_name = current.file_name()?.to_string_lossy();
+        if file_name == "MacOS" {
+            let contents_dir = current.parent()?;
+            let plist_path = contents_dir.join("Info.plist");
+            if !plist_path.exists() {
+                return None;
+            }
+
+            let value = plist::Value::from_file(&plist_path).ok()?;
+            let dict = value.as_dictionary()?;
+
+            if let Some(version) = dict
+                .get("CFBundleShortVersionString")
+                .and_then(|v| v.as_string())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+            {
+                return Some(version.to_string());
+            }
+
+            return dict
+                .get("CFBundleVersion")
+                .and_then(|v| v.as_string())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+        }
+
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_macos_bundle_version(_exe_path: &Path) -> Option<String> {
     None
 }
 

--- a/src/data/modelDirectory.json
+++ b/src/data/modelDirectory.json
@@ -176,6 +176,38 @@
       "anthropicUrl": "",
       "modelId": "",
       "region": "global"
+    },
+    {
+      "name": "SiliconFlow 硅基流动",
+      "url": "https://siliconflow.cn",
+      "baseUrl": "https://api.siliconflow.cn/v1",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "cn"
+    },
+    {
+      "name": "PPIO 派欧云",
+      "url": "https://ppinfra.com",
+      "baseUrl": "https://api.ppinfra.com/v3/openai",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "cn"
+    },
+    {
+      "name": "302.AI",
+      "url": "https://302.ai",
+      "baseUrl": "https://api.302.ai/v1",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "global"
+    },
+    {
+      "name": "OpenAI-Compatible Custom",
+      "url": "",
+      "baseUrl": "",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "global"
     }
   ],
   "relays": [
@@ -199,6 +231,30 @@
       "name": "B.ai",
       "url": "https://b.ai",
       "baseUrl": "https://api.theb.ai/v1",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "global"
+    },
+    {
+      "name": "One API",
+      "url": "https://github.com/songquanpeng/one-api",
+      "baseUrl": "",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "global"
+    },
+    {
+      "name": "New API",
+      "url": "https://github.com/QuantumNous/new-api",
+      "baseUrl": "",
+      "anthropicUrl": "",
+      "modelId": "",
+      "region": "global"
+    },
+    {
+      "name": "LibreChat AI Gateway",
+      "url": "https://www.librechat.ai",
+      "baseUrl": "",
       "anthropicUrl": "",
       "modelId": "",
       "region": "global"

--- a/src/pages/AppManager/AppManagerComponents.tsx
+++ b/src/pages/AppManager/AppManagerComponents.tsx
@@ -3,12 +3,15 @@ import { Server as ServerIcon, Box as BoxIcon } from 'lucide-react';
 import { ToolCard, getModelIcon } from '../../components';
 import { useI18n } from '../../hooks/useI18n';
 import type { ModelConfig, LocalTool } from '../../api/types';
+import type { BundledProviderPreset } from './context';
 import { useAppManager, toolCategories } from './context';
 import {
   getOfficialEndpoint,
   officialModelSentinel,
   type OfficialEndpoint,
 } from '../../data/officialEndpoints';
+
+type TranslationKey = Parameters<ReturnType<typeof useI18n>['t']>[0];
 
 // ===== Main Content (tool cards grid) =====
 
@@ -53,7 +56,7 @@ export const AppManagerMain: React.FC = () => {
                   Desktop: 'toolCat.desktop',
                   Utility: 'toolCat.utility',
                 };
-                return t((catMap[cat] || cat) as any);
+                return t((catMap[cat] || cat) as TranslationKey);
               })()}
             </button>
           ))}
@@ -149,6 +152,7 @@ export const AppManagerMain: React.FC = () => {
 interface ModelListSectionProps {
   selectedToolData: LocalTool;
   userModels: ModelConfig[];
+  bundledProviderPresets: BundledProviderPreset[];
   toolModelConfig: Record<string, string | null>;
   selectedTool: string | null;
   handleSelectModel: (toolId: string, modelId: string) => void;
@@ -156,12 +160,13 @@ interface ModelListSectionProps {
   setModelProtocolSelection: React.Dispatch<
     React.SetStateAction<Record<string, 'openai' | 'anthropic'>>
   >;
-  t: (key: any) => string;
+  t: (key: TranslationKey) => string;
 }
 
 export const ModelListSection: React.FC<ModelListSectionProps> = ({
   selectedToolData,
   userModels,
+  bundledProviderPresets,
   toolModelConfig,
   selectedTool,
   handleSelectModel,
@@ -169,19 +174,42 @@ export const ModelListSection: React.FC<ModelListSectionProps> = ({
   setModelProtocolSelection,
   t,
 }) => {
-  const toolProtocols = selectedToolData.apiProtocol || ['openai', 'anthropic'];
+  const toolProtocols = useMemo(
+    () => selectedToolData.apiProtocol || ['openai', 'anthropic'],
+    [selectedToolData.apiProtocol]
+  );
 
-  const { localModels, cloudModels } = useMemo(() => {
+  const { localModels, cloudModels, presetModels } = useMemo(() => {
     const compatible = userModels.filter((model) => {
       const hasOpenAI = toolProtocols.includes('openai') && !!model.baseUrl;
       const hasAnthropic = toolProtocols.includes('anthropic') && !!model.anthropicUrl;
       return hasOpenAI || hasAnthropic;
     });
+
+    const compatiblePresets = bundledProviderPresets.filter((preset) => {
+      const hasOpenAI = toolProtocols.includes('openai') && !!preset.baseUrl;
+      const hasAnthropic = toolProtocols.includes('anthropic') && !!preset.anthropicUrl;
+      return hasOpenAI || hasAnthropic;
+    });
+
+    const existingKeys = new Set(
+      compatible.map(
+        (model) =>
+          `${model.name}::${model.baseUrl}::${model.anthropicUrl || ''}::${model.modelId || ''}`
+      )
+    );
+
     return {
       localModels: compatible.filter((m) => m.internalId === 'local-server'),
       cloudModels: compatible.filter((m) => m.internalId !== 'local-server'),
+      presetModels: compatiblePresets.filter(
+        (preset) =>
+          !existingKeys.has(
+            `${preset.name}::${preset.baseUrl}::${preset.anthropicUrl || ''}::${preset.modelId || ''}`
+          )
+      ),
     };
-  }, [userModels, toolProtocols]);
+  }, [userModels, bundledProviderPresets, toolProtocols]);
 
   const renderModelCard = (model: (typeof userModels)[0]) => {
     const isSelected = selectedTool ? toolModelConfig[selectedTool] === model.internalId : false;
@@ -303,6 +331,85 @@ export const ModelListSection: React.FC<ModelListSectionProps> = ({
     );
   };
 
+  const renderPresetCard = (preset: BundledProviderPreset) => {
+    const isSelected = selectedTool ? toolModelConfig[selectedTool] === preset.internalId : false;
+    const showSwitcher = !!(preset.baseUrl && preset.anthropicUrl) && toolProtocols.length > 1;
+    const currentProtocol =
+      modelProtocolSelection[preset.modelId || preset.internalId] ||
+      (toolProtocols[0] === 'anthropic' ? 'anthropic' : 'openai');
+    const displayUrl =
+      currentProtocol === 'anthropic'
+        ? preset.anthropicUrl || preset.baseUrl
+        : preset.baseUrl || preset.anthropicUrl || '';
+    const apiPath = (() => {
+      try {
+        const url = new URL(displayUrl || '');
+        const path = url.pathname === '/' ? '' : url.pathname;
+        return url.hostname + path;
+      } catch {
+        return displayUrl || 'No URL Configured';
+      }
+    })();
+    const iconSrc = getModelIcon(preset.name, preset.modelId || '');
+
+    return (
+      <div
+        key={preset.internalId}
+        className={`p-3 rounded cursor-pointer transition-colors mb-2 flex items-center gap-3 border bg-cyber-surface ${
+          isSelected ? 'border-cyber-accent' : 'border-transparent hover:bg-cyber-elevated'
+        }`}
+        onClick={() => selectedTool && handleSelectModel(selectedTool, preset.internalId)}
+      >
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="w-4 h-4 rounded-full border-2 border-cyber-border flex items-center justify-center">
+            {isSelected && <div className="w-2 h-2 rounded-full bg-cyber-accent" />}
+          </div>
+          {iconSrc ? (
+            <img
+              src={iconSrc}
+              alt=""
+              className="w-6 h-6"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          ) : (
+            <div className="w-6 h-6 rounded bg-cyber-text/15 flex items-center justify-center text-cyber-text">
+              <BoxIcon size={14} />
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0 flex flex-col justify-center min-h-[2.5rem] py-0.5">
+          <div className="flex items-start gap-2">
+            <div className="text-sm font-bold truncate leading-none flex-1 min-w-0">
+              {preset.name}
+            </div>
+            {showSwitcher && (
+              <span
+                className="text-[10px] font-mono cursor-pointer select-none flex-shrink-0 transition-colors text-cyber-text-muted/60 hover:text-cyber-text"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const newProtocol = currentProtocol === 'openai' ? 'anthropic' : 'openai';
+                  setModelProtocolSelection((prev) => ({
+                    ...prev,
+                    [preset.modelId || preset.internalId]: newProtocol,
+                  }));
+                }}
+              >
+                {currentProtocol === 'openai' ? 'OpenAI' : 'Anthropic'}{' '}
+                <span className="text-[8px]">⇄</span>
+              </span>
+            )}
+          </div>
+          <div className="text-[10px] text-cyber-text-secondary truncate leading-tight mt-1 opacity-70">
+            {apiPath}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   // Official-endpoint card — first item, like cc-switch's "Claude Official"
   const official = selectedTool ? getOfficialEndpoint(selectedTool) : undefined;
   const officialSentinel = selectedTool ? officialModelSentinel(selectedTool) : '';
@@ -372,7 +479,8 @@ export const ModelListSection: React.FC<ModelListSectionProps> = ({
   // Fully empty: no local models, no cloud models, no official endpoint.
   // Show only the centered placeholder — the "select model for X" heading
   // would be misleading when there's nothing to select anyway.
-  const isEmpty = cloudModels.length === 0 && !official && localModels.length === 0;
+  const isEmpty =
+    cloudModels.length === 0 && presetModels.length === 0 && !official && localModels.length === 0;
   if (isEmpty) {
     return (
       <div className="h-full flex flex-col items-center justify-center gap-3 text-center">
@@ -404,6 +512,7 @@ export const ModelListSection: React.FC<ModelListSectionProps> = ({
       <div className="space-y-2">
         {official && renderOfficialCard(official)}
         {cloudModels.map(renderModelCard)}
+        {presetModels.map(renderPresetCard)}
       </div>
     </>
   );
@@ -417,6 +526,7 @@ export const AppManagerPanel: React.FC = () => {
     selectedToolData,
     selectedTool,
     userModels,
+    bundledProviderPresets,
     toolModelConfig,
     handleSelectModel,
     modelProtocolSelection,
@@ -451,6 +561,7 @@ export const AppManagerPanel: React.FC = () => {
               <ModelListSection
                 selectedToolData={selectedToolData}
                 userModels={userModels}
+                bundledProviderPresets={bundledProviderPresets}
                 toolModelConfig={toolModelConfig}
                 selectedTool={selectedTool}
                 handleSelectModel={handleSelectModel}

--- a/src/pages/AppManager/AppManagerProvider.tsx
+++ b/src/pages/AppManager/AppManagerProvider.tsx
@@ -3,10 +3,20 @@ import { useConfirm } from '../../components/ConfirmDialog';
 import { useI18n } from '../../hooks/useI18n';
 import * as api from '../../api/tauri';
 import type { ModelConfig } from '../../api/types';
-import { AppManagerContext } from './context';
+import { AppManagerContext, BundledProviderPreset } from './context';
 import { useToolsStore } from '../../stores/toolsStore';
 import { useNavigationStore } from '../../stores/navigationStore';
 import { getOfficialEndpoint, isOfficialModelSentinel } from '../../data/officialEndpoints';
+import modelDirectory from '../../data/modelDirectory.json';
+
+type ModelDirectoryEntry = {
+  name?: string;
+  url?: string;
+  baseUrl?: string;
+  anthropicUrl?: string;
+  modelId?: string;
+  region?: string;
+};
 
 // ===== Provider =====
 
@@ -29,6 +39,36 @@ export const AppManagerProvider: React.FC<AppManagerProviderProps> = ({ children
   } = useToolsStore();
   const { activePage, goToMother } = useNavigationStore();
   const isActive = activePage === 'apps';
+
+  const bundledProviderPresets = React.useMemo<BundledProviderPreset[]>(() => {
+    const directory = modelDirectory as {
+      providers?: ModelDirectoryEntry[];
+      relays?: ModelDirectoryEntry[];
+    };
+    const entries = [...(directory.providers || []), ...(directory.relays || [])];
+
+    return entries
+      .filter((entry) => entry && (entry.baseUrl || entry.anthropicUrl))
+      .map((entry) => {
+        const baseUrl = entry.baseUrl || '';
+        const anthropicUrl = entry.anthropicUrl || '';
+        const modelId = entry.modelId || '';
+        const slug = String(entry.name || 'provider')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+
+        return {
+          internalId: `bundled:${slug}:${modelId || 'default'}`,
+          name: entry.name || 'Provider',
+          baseUrl,
+          anthropicUrl,
+          modelId,
+          url: entry.url || '',
+          region: entry.region || '',
+        };
+      });
+  }, []);
 
   // Wrapped navigation: build prefill and go to Mother Agent (model check happens there)
   const handleGoToMother = useCallback(
@@ -129,6 +169,35 @@ export const AppManagerProvider: React.FC<AppManagerProviderProps> = ({ children
       [toolId]: modelId,
     }));
   };
+
+  const ensureBundledPresetModel = useCallback(
+    async (presetId: string): Promise<string | null> => {
+      if (!presetId.startsWith('bundled:')) return presetId;
+
+      const preset = bundledProviderPresets.find((item) => item.internalId === presetId);
+      if (!preset) return null;
+
+      const existing = userModels.find(
+        (model) =>
+          model.name === preset.name &&
+          model.baseUrl === preset.baseUrl &&
+          (model.anthropicUrl || '') === (preset.anthropicUrl || '') &&
+          (model.modelId || '') === (preset.modelId || '')
+      );
+      if (existing) return existing.internalId;
+
+      const created = await api.addModel({
+        name: preset.name,
+        baseUrl: preset.baseUrl,
+        anthropicUrl: preset.anthropicUrl || undefined,
+        apiKey: '',
+        modelId: preset.modelId || undefined,
+      });
+      setUserModels((prev) => [...prev, created]);
+      return created.internalId;
+    },
+    [bundledProviderPresets, userModels]
+  );
 
   // Get selected tool data
   const selectedToolData = detectedTools.find((t) => t.id === selectedTool);
@@ -234,10 +303,21 @@ export const AppManagerProvider: React.FC<AppManagerProviderProps> = ({ children
     // Launchable tools (e.g. games) always pass config via URL hash, never via file write.
     // no-model-config tools (e.g. desktop apps) skip config writes entirely.
     if (!noModelConfig && agreedConfigPolicy && !isLaunchable && toolModelConfig[selectedTool]) {
-      const pending = toolModelConfig[selectedTool]!;
+      let pending = toolModelConfig[selectedTool]!;
       const applyResult = isOfficialModelSentinel(pending)
         ? await applyRestore(selectedTool)
-        : await applyModelConfig(selectedTool, pending);
+        : await (async () => {
+            const resolvedModelId = await ensureBundledPresetModel(pending);
+            if (!resolvedModelId) return false;
+            if (resolvedModelId !== pending) {
+              setToolModelConfig((prev) => ({
+                ...prev,
+                [selectedTool]: resolvedModelId,
+              }));
+            }
+            pending = resolvedModelId;
+            return applyModelConfig(selectedTool, resolvedModelId);
+          })();
       if (applyResult !== true) {
         setApplyError(typeof applyResult === 'string' ? applyResult : t('key.destroyed'));
         setIsLaunching(false);
@@ -300,6 +380,7 @@ export const AppManagerProvider: React.FC<AppManagerProviderProps> = ({ children
         isScanning,
         scanTools,
         userModels,
+        bundledProviderPresets,
         modelProtocolSelection,
         setModelProtocolSelection,
         handleLaunch,

--- a/src/pages/AppManager/context.ts
+++ b/src/pages/AppManager/context.ts
@@ -1,6 +1,16 @@
 import { createContext, useContext } from 'react';
 import type { ModelConfig, LocalTool } from '../../api/types';
 
+export interface BundledProviderPreset {
+  internalId: string;
+  name: string;
+  baseUrl: string;
+  anthropicUrl?: string;
+  modelId?: string;
+  url?: string;
+  region?: string;
+}
+
 // ===== Context =====
 
 export interface AppManagerContextType {
@@ -27,6 +37,7 @@ export interface AppManagerContextType {
   isScanning: boolean;
   scanTools: () => Promise<void>;
   userModels: ModelConfig[];
+  bundledProviderPresets: BundledProviderPreset[];
   modelProtocolSelection: Record<string, 'openai' | 'anthropic'>;
   setModelProtocolSelection: React.Dispatch<
     React.SetStateAction<Record<string, 'openai' | 'anthropic'>>

--- a/tools/codex/paths.json
+++ b/tools/codex/paths.json
@@ -20,6 +20,7 @@
             "%LOCALAPPDATA%/pnpm/codex.exe"
         ],
         "darwin": [
+            "/Applications/ServBay/package/node/current/bin/codex",
             "/usr/local/bin/codex",
             "/opt/homebrew/bin/codex",
             "~/.bun/bin/codex",

--- a/tools/openclaw/paths.json
+++ b/tools/openclaw/paths.json
@@ -23,6 +23,8 @@
             "%USERPROFILE%/.local/bin/openclaw.exe"
         ],
         "darwin": [
+            "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+            "/Applications/ServBay/package/node/current/bin/openclaw",
             "/usr/local/bin/openclaw",
             "/opt/homebrew/bin/openclaw",
             "~/Library/pnpm/openclaw",


### PR DESCRIPTION
## 摘要

这个 PR 主要解决 EchoBird 在真实 macOS 使用场景下的 5 类问题：

- 桌面应用版本号显示为 `-`
- 已安装的 OpenClaw 桌面版仍被误判为“未安装”
- ServBay Node 环境下已安装的 `codex` / `openclaw` CLI 没有被识别出来
- 应用管理右侧面板只显示“已保存模型 + OpenAI Official”，没有把 EchoBird 自带的 provider / relay 目录真正展示出来
- frameless 窗口下左侧导航的命中/可访问性不稳定，导致页面切换和实机验收都不可靠

此外，这个 PR 还顺手修复了当前仓库在 Tailwind v4 下的 PostCSS 构建断点，并补了一处根容器高度策略问题，确保仓库现在可以完整跑通前端构建和 Tauri 打包，且 UI 壳层恢复到可正常使用的状态。

## 背景

这组修改来自一个真实的 macOS 使用场景：我在尝试用 EchoBird 替换 CC Switch 时，发现应用管理和相关页面存在多处识别、适配和 UI 运行态问题。

具体表现如下：

1. `Codex Desktop`、`Cursor`、`ClaudeCode` 可能显示 `版本: -`
2. `OpenClaw` 明明已经在本地安装并运行，但 EchoBird 仍然显示 “AI 自动安装”
3. `codex` 和 `openclaw` CLI 明明已经安装在本机，可执行路径分别是：
   - `/Applications/ServBay/package/node/current/bin/codex`
   - `/Applications/ServBay/package/node/current/bin/openclaw`
   但 EchoBird 没有识别出来
4. 应用管理右侧模型通道面板的可选项明显少于预期，看起来远弱于 CC Switch
5. 修完前几项之后，frameless 窗口下左侧导航仍然存在命中不稳定问题，导致页面切换、无障碍树读取和实机验收都不够可靠

## 根因分析

### 1. 桌面应用版本号

当前 `scan_single_tool()` 的版本探测逻辑主要依赖 CLI `--version`，并且会跳过桌面类 launch-only app。

这会导致：

- `codexdesktop` 这类桌面应用除非硬编码版本，否则天然拿不到版本号
- macOS app bundle 里本来就存在的 `Info.plist` 版本信息没有被利用

### 2. OpenClaw 安装识别

`tools/openclaw/paths.json` 在 macOS 下只列了 CLI 路径，没有覆盖：

- `/Applications/OpenClaw.app/Contents/MacOS/OpenClaw`

所以安装了桌面版但不依赖 CLI 路径时，会被误判为“未安装”。

### 3. Codex / OpenClaw CLI 识别

当前 macOS 路径规则里没有覆盖 ServBay 的 Node 全局 bin 路径：

- `/Applications/ServBay/package/node/current/bin/codex`
- `/Applications/ServBay/package/node/current/bin/openclaw`

虽然 EchoBird 也有 PATH / login shell fallback，但在 GUI 应用环境里，单靠 PATH 继承并不稳定，显式路径规则仍然有必要。

### 4. 应用管理右侧模型通道面板

`src/data/modelDirectory.json` 里其实已经有一份 bundled provider / relay 目录，但 App Manager 右侧面板没有用它。

当前右侧面板只会显示：

- EchoBird 自己已经保存过的 `userModels`
- 官方恢复项（如 `OpenAI Official`）

所以用户看起来会以为“右侧通道列表不全”。

### 5. 左侧导航命中和可访问性

当前 `NavItem` 使用的是 `div + onClick`，而不是语义化可交互元素。

这在普通鼠标使用时问题不一定明显，但在 macOS frameless + transparent 窗口组合下，会放大两个问题：

- 命中行为不稳定，不利于实机切页验证
- 无障碍树暴露不完整，自动化和辅助技术很难稳定识别导航项

### 6. 根容器高度策略

根容器使用固定 `height: 100vh`。在 Tauri/macOS 的透明无边框窗口里，这种写法在某些运行态下更容易出现根容器高度和窗口可视区域不完全贴合的问题，进一步放大了“页面看起来不正常”的感知。

## 本 PR 的修改内容

### 后端：安装识别和版本探测

- 新增 macOS app bundle 版本读取逻辑：
  - 优先读取 `CFBundleShortVersionString`
  - 失败时回退到 `CFBundleVersion`
- 保留 CLI `--version` 探测
- 再增加一层“对已探测到的可执行绝对路径直接跑 `--version`”的兜底逻辑

### 工具路径规则

- 为 OpenClaw 增加桌面版 macOS 路径：
  - `/Applications/OpenClaw.app/Contents/MacOS/OpenClaw`
- 为 `codex` 和 `openclaw` 增加 ServBay Node 环境路径：
  - `/Applications/ServBay/package/node/current/bin/codex`
  - `/Applications/ServBay/package/node/current/bin/openclaw`

### 应用管理右侧模型通道面板

- 让 App Manager 真正展示 bundled provider presets
- 选中 bundled preset 时，会先落成普通 EchoBird model，再复用现有 apply pipeline
- 保持现有 saved model 流程和官方恢复逻辑不变

### 补充 bundled provider / relay 目录

新增了一批高价值条目：

- `SiliconFlow 硅基流动`
- `PPIO 派欧云`
- `302.AI`
- `OpenAI-Compatible Custom`
- `One API`
- `New API`
- `LibreChat AI Gateway`

### 左侧导航交互修复

- 将 `NavItem` 从 `div + onClick` 改为真正的 `button`
- 保留原有视觉风格和行为不变
- 让导航项在无障碍树里稳定暴露为可点击按钮，方便真实用户操作，也方便自动化实机验收

### 根容器高度修复

- 将 `#root` 从固定 `height: 100vh` 改为：
  - `width: 100%`
  - `min-height: 100vh`
  - `min-height: 100dvh`

这能让窗口根容器在透明无边框场景下更稳地贴合实际可视区。

### 构建链修复

- 将 PostCSS 中的 Tailwind 插件切换到 `@tailwindcss/postcss`
- 补上缺失依赖，修复当前仓库在 Tailwind v4 下的构建失败问题
- 将 CSS 入口改为 Tailwind v4 推荐写法，并显式声明 source 范围

## 验证情况

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- 本机路径存在性验证通过：
  - Codex Desktop
  - OpenClaw Desktop
  - Cursor
  - ServBay 下的 `codex` / `openclaw` CLI
- 本机 bundle version 读取通过：
  - `Codex.app`
  - `Cursor.app`
  - `OpenClaw.app`
- `npm run typecheck` ✅
- `npx vite build` ✅
- `npx @tauri-apps/cli build` ✅
- 本机替换安装并实机复验后确认：
  - 左侧导航已能稳定暴露为可点击按钮
  - `应用管理` 页面可正常切入
  - `Codex Desktop` / `OpenClaw` / `Codex CLI` 的识别与版本信息已恢复
  - 右侧模型通道列表不再只剩 `OpenAI Official`
  - `模型中心` 页面可正常切入

## 本 PR 暂未覆盖

- 不读取 `~/.cc-switch/cc-switch.db`
- 不做“模型中心自动回读 / 自动导入现有软件和 CLI 的模型配置”
  - 当前“模型中心”这一块确实还缺少类似 CC Switch 的现有配置识别与导入能力
  - 但这属于下一阶段能力建设，不是这次应用识别和页面恢复修复的范围
- 不重做 App Manager / Model Center 的整体交互布局
- 不引入后台同步或 watcher
