### PR TITLE
feat(ui): themed auto-hide scrollbar on AI 资讯 / 明星项目 / AI 公开课

### DIFF
--- a/src/hooks/usePulseScroll.ts
+++ b/src/hooks/usePulseScroll.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef } from 'react';
+
+// Attach the returned callback ref to a scroll container and pair the
+// element with the `.pulse-scroll` CSS class. The hook toggles an
+// `is-scrolling` class on the element during scroll motion and clears it
+// 1s after the last scroll event, giving a macOS-style auto-hide
+// scrollbar without any re-renders. `:hover` keeps the scrollbar visible
+// while the cursor is over the container (handled in CSS).
+//
+// Uses a callback ref so consumers with conditional renders (e.g. a list
+// that swaps between loading skeleton / error / result divs) re-attach
+// cleanly when the target element changes.
+export function usePulseScroll<T extends HTMLElement>(): (el: T | null) => void {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  return useCallback((el: T | null) => {
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = null;
+    }
+    if (!el) return;
+    let timer: number | undefined;
+    const onScroll = () => {
+      el.classList.add('is-scrolling');
+      if (timer !== undefined) window.clearTimeout(timer);
+      timer = window.setTimeout(() => el.classList.remove('is-scrolling'), 1000);
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    cleanupRef.current = () => {
+      el.removeEventListener('scroll', onScroll);
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,41 @@ pre {
   background: rgba(255, 255, 255, 0.18);
 }
 
+/* Auto-hide themed scrollbar — for AI 资讯 / 明星项目 / AI 公开课 lists
+ * and their sidebars. Pair with the `usePulseScroll` ref hook: it toggles
+ * `.is-scrolling` on scroll motion and clears it 1s after the user stops,
+ * so the scrollbar fades out on idle. Hover over the container keeps it
+ * visible. Width is 5px (occupies layout, but the gutter is barely
+ * perceptible vs the OS-default 15-17px) and the thumb uses the brand
+ * accent at 35% so it reads as themed without competing with content.
+ * Overrides the global `::-webkit-scrollbar { display: none }` above. */
+.pulse-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.3s ease;
+}
+.pulse-scroll::-webkit-scrollbar {
+  display: block;
+  width: 5px;
+  height: 5px;
+}
+.pulse-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.pulse-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+  transition: background 0.3s ease;
+}
+.pulse-scroll.is-scrolling,
+.pulse-scroll:hover {
+  scrollbar-color: rgb(var(--accent-rgb) / 0.35) transparent;
+}
+.pulse-scroll.is-scrolling::-webkit-scrollbar-thumb,
+.pulse-scroll:hover::-webkit-scrollbar-thumb {
+  background: rgb(var(--accent-rgb) / 0.35);
+}
+
 /* Pure-white SVG logos invert in light mode so they read on the cream
    card surface. Logos with mixed colors are skipped (the filter would
    shift their accent hues). */

--- a/src/pages/AiCourses/AiCourses.tsx
+++ b/src/pages/AiCourses/AiCourses.tsx
@@ -17,6 +17,7 @@ import {
 import { open as shellOpen } from '@tauri-apps/plugin-shell';
 import { ExternalLink, RefreshCw } from 'lucide-react';
 import { useI18n } from '../../hooks/useI18n';
+import { usePulseScroll } from '../../hooks/usePulseScroll';
 
 // ===== Mirror config =====
 
@@ -558,6 +559,7 @@ function CourseCard({ course }: { course: Course }) {
 export function AiCoursesMain() {
   const { t, locale } = useI18n();
   const { catalog, initialLoading, syncing, error, selectedCategory, retry } = useAiCourses();
+  const scrollRef = usePulseScroll<HTMLDivElement>();
   // Only zh-Hans gets the CN supplement (李宏毅 / 李沐 / 飞桨 etc. on Bilibili
   // and CN-domestic platforms). zh-Hant (TW/HK/MO) and ja users see the
   // upstream dair-ai EN list — TW/HK devs follow the international AI stack
@@ -607,7 +609,7 @@ export function AiCoursesMain() {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto pb-4">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto pb-4 pulse-scroll">
       {/* Reserved 2px slot — opacity toggle prevents layout shift on sync start/stop */}
       <div className="sticky top-0 z-20 h-0.5 overflow-hidden pointer-events-none mb-2">
         <div
@@ -630,6 +632,7 @@ export function AiCoursesMain() {
 export function AiCoursesPanel() {
   const { t, locale } = useI18n();
   const { catalog, selectedCategory, setSelectedCategory } = useAiCourses();
+  const scrollRef = usePulseScroll<HTMLDivElement>();
   // Only zh-Hans gets the CN supplement (李宏毅 / 李沐 / 飞桨 etc. on Bilibili
   // and CN-domestic platforms). zh-Hant (TW/HK/MO) and ja users see the
   // upstream dair-ai EN list — TW/HK devs follow the international AI stack
@@ -661,7 +664,7 @@ export function AiCoursesPanel() {
         <div className="text-[15px] font-semibold text-cyber-text">{t('courses.filter')}</div>
         {total > 0 && <span className="text-[13px] font-mono text-cyber-text-muted">{total}</span>}
       </div>
-      <div className="flex-1 px-2 overflow-y-auto pb-4 space-y-1">
+      <div ref={scrollRef} className="flex-1 px-2 overflow-y-auto pb-4 space-y-1 pulse-scroll">
         <button
           onClick={() => setSelectedCategory('all')}
           className={`w-full text-left px-3 py-2 rounded text-[14px] transition-colors flex items-center justify-between ${

--- a/src/pages/AiPulse/AiPulse.tsx
+++ b/src/pages/AiPulse/AiPulse.tsx
@@ -29,6 +29,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { open as shellOpen } from '@tauri-apps/plugin-shell';
 import { ChevronDown, ChevronRight, ExternalLink, RefreshCw } from 'lucide-react';
 import { useI18n } from '../../hooks/useI18n';
+import { usePulseScroll } from '../../hooks/usePulseScroll';
 import type { TKey } from '../../i18n';
 
 // ===== Mirror config =====
@@ -698,16 +699,18 @@ function ItemFeed({ variant }: { variant: PageVariant }) {
 }
 
 export function AiNewsMain() {
+  const scrollRef = usePulseScroll<HTMLDivElement>();
   return (
-    <div className="flex-1 overflow-y-auto pb-4">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto pb-4 pulse-scroll">
       <ItemFeed variant="news" />
     </div>
   );
 }
 
 export function AiProjectsMain() {
+  const scrollRef = usePulseScroll<HTMLDivElement>();
   return (
-    <div className="flex-1 overflow-y-auto pb-4">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto pb-4 pulse-scroll">
       <ItemFeed variant="projects" />
     </div>
   );
@@ -751,6 +754,7 @@ function groupByMonth(dates: string[]): Map<string, string[]> {
 export function AiPulsePanel({ variant = 'news' }: { variant?: PageVariant }) {
   const { t } = useI18n();
   const { items, selectedDate, selectDate, feedSource } = useAiPulse();
+  const scrollRef = usePulseScroll<HTMLDivElement>();
   // Date-button counts must mirror ItemFeed's filter (feedSource, not
   // locale) so the number on each date button reflects what the user
   // will actually see when they click.
@@ -817,7 +821,7 @@ export function AiPulsePanel({ variant = 'news' }: { variant?: PageVariant }) {
       <div className="px-3 py-2 mb-1 bg-transparent">
         <div className="text-[15px] font-semibold text-cyber-text">{t('pulse.archive')}</div>
       </div>
-      <div className="flex-1 px-2 overflow-y-auto pb-4">
+      <div ref={scrollRef} className="flex-1 px-2 overflow-y-auto pb-4 pulse-scroll">
         {cachedDates.length === 0 ? (
           <div className="px-3 py-8 text-center text-[14px] text-cyber-text-muted leading-relaxed">
             {t('pulse.loadingFirst')}


### PR DESCRIPTION
## Summary

Adds a brand-themed auto-hide scrollbar to the 5 scroll containers across
the three content-list pages (AI 资讯, 明星项目, AI 公开课). 5px wide,
brand accent at 35% opacity, fades in on scroll motion and fades out 1s
after the user stops. Hovering the container keeps it visible.

Replaces the visual nothing (global `::-webkit-scrollbar { display: none }`)
on these specific containers with a quiet themed indicator that matches
the cream/coral EchoBird identity.

## Scope

| Component | Container |
|---|---|
| AiNewsMain | AI 资讯 main waterfall |
| AiProjectsMain | 明星项目 main waterfall |
| AiPulsePanel | 历史归档 right sidebar |
| AiCoursesMain | AI 公开课 grid |
| AiCoursesPanel | category filter right sidebar |

Other scroll surfaces (modals, dropdowns, chat, code blocks, settings)
are untouched — the `.pulse-scroll` class is opt-in.

## Implementation

- New `usePulseScroll` callback-ref hook ([src/hooks/usePulseScroll.ts](src/hooks/usePulseScroll.ts))
  toggles an `is-scrolling` class on scroll events and clears it 1s
  after the last scroll. Callback ref (not `useRef + useEffect`) so
  AiCoursesMain's conditional render (loading / error / result divs)
  re-attaches cleanly when the target element changes.
- CSS in [src/index.css](src/index.css) overrides the global hidden-scrollbar
  rule only for `.pulse-scroll` elements. Uses `rgb(var(--accent-rgb) / 0.35)`
  so both light and dark themes get correct theming.

## Trade-offs documented in code

- 5px gutter occupies layout (overlay scrollbars are deprecated in
  WebKit). At 5px vs OS-default 15-17px the visual cost is negligible
  while the polish is meaningful.
- Loading/error short-lived states in AiCoursesMain are intentionally
  not given the ref — they don't usually overflow and would just add
  noise during the brief skeleton render.

## Risk

- No version bump, no Rust, no schema, no data flow change
- Pure frontend polish, ~80 lines added across 4 files
- Other scrollbar styles (`.custom-scrollbar` for chat, `.slim-scroll`)
  unaffected — different classes, different rules

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint` — 44 warnings (0 added, threshold 45)
- [x] `tsc --noEmit` — clean
- [ ] Local `run-repo-dev.bat`: visit AI 资讯, scroll, observe themed bar fades in on motion + out after 1s
- [ ] Hover scrollbar area — stays visible
- [ ] Switch between AI 资讯 / 明星项目 / AI 公开课 — scrollbar present on all three
- [ ] Confirm dropdowns / modals elsewhere still have no visible scrollbar