### PR TITLE
fix(pulse): normalize future-stamped published_at to first_seen_at

### DIFF
--- a/scripts/filter_pulse.py
+++ b/scripts/filter_pulse.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Match the full host segment (incl. any subdomain). Three hosts:
@@ -46,7 +47,57 @@ BLOCKED_TITLE_RE = re.compile(
 )
 
 
-def filter_file(path: Path) -> tuple[int, int]:
+# Some upstream aggregators (newsnow + juejin in particular, a few wechat
+# scrapers occasionally) stamp Beijing time as if it were UTC, so a story
+# published at 16:24 CST gets written as "2026-05-23T16:24:59Z" — 8h in
+# the future relative to the snapshot's own clock. That bad row sorts to
+# the top of the user-facing feed while the relative-time label correctly
+# shows "10 小时前", which looks broken.
+#
+# Rewrite the offending published_at to the upstream-recorded
+# first_seen_at (which is set when we first crawled the URL, so it's
+# always real) so the row lands at its true chronological position.
+# 5-minute slack matches the frontend's itemTs() guard.
+FUTURE_SLACK = timedelta(minutes=5)
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    # fromisoformat accepts "...+00:00" but not "...Z" pre-3.11; normalize.
+    s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def normalize_future_timestamps(payload: dict) -> int:
+    """Rewrite published_at when it sits ahead of the snapshot clock.
+
+    Reference time is the payload's own ``generated_at`` (deterministic
+    across workflow re-runs); falls back to wall-clock UTC. Returns the
+    count of rewritten items for observability in the action log.
+    """
+    reference = _parse_iso(payload.get("generated_at")) or datetime.now(timezone.utc)
+    cutoff = reference + FUTURE_SLACK
+    fixed = 0
+    for it in payload.get("items") or []:
+        pub = _parse_iso(it.get("published_at"))
+        if pub is None or pub <= cutoff:
+            continue
+        fallback = it.get("first_seen_at") or it.get("last_seen_at")
+        if not fallback:
+            continue
+        it["published_at"] = fallback
+        fixed += 1
+    return fixed
+
+
+def filter_file(path: Path) -> tuple[int, int, int]:
     text = path.read_text(encoding="utf-8")
     payload = json.loads(text)
     items = payload.get("items") or []
@@ -59,13 +110,14 @@ def filter_file(path: Path) -> tuple[int, int]:
     ]
     payload["items"] = kept
     payload["total_items"] = len(kept)
+    fixed = normalize_future_timestamps(payload)
     # Preserve the upstream's indent style so refresh commits show only the
     # actual content delta, not a wholesale reformat. SuYxh's ZH files ship
     # with indent=2; our EN builder writes indent=0. Sniff by peeking at the
     # first child line — indented vs flush-left.
     indent = 2 if len(text) > 2 and text[1] == "\n" and text[2] == " " else 0
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=indent), encoding="utf-8")
-    return before, len(kept)
+    return before, len(kept), fixed
 
 
 def main(argv: list[str]) -> int:
@@ -74,9 +126,9 @@ def main(argv: list[str]) -> int:
         return 2
     for arg in argv[1:]:
         path = Path(arg)
-        before, after = filter_file(path)
+        before, after, fixed = filter_file(path)
         dropped = before - after
-        print(f"{path}: {before} → {after} ({dropped} dropped)")
+        print(f"{path}: {before} → {after} ({dropped} dropped, {fixed} ts-normalized)")
     return 0
 
 


### PR DESCRIPTION
## Summary
- A few upstream sources (newsnow+juejin, some wechat scrapers) stamp Beijing time as if it were UTC, putting `published_at` up to 8h ahead of the snapshot's own clock. The bad row gets pinned to the top of the feed while the relative-time label (which has its own future-guard) correctly says "10 小时前" — looks broken.
- Add `normalize_future_timestamps()` to `scripts/filter_pulse.py`: rows where `published_at > generated_at + 5min` get rewritten to `first_seen_at` (or `last_seen_at`).
- Runs **after** the existing host/title blocklist — blocked items can never be revived through normalization.
- Idempotent: re-running on already-normalized data is a no-op.

## Scope
- **App code untouched.** No frontend, no Rust, no version bump.
- Only the bot-side cleanup script (`scripts/filter_pulse.py`) — same place we already strip x.com / v2ex / 广告 titles.
- Existing blocklists fully preserved.

## Test plan
- [x] Dry-run against current `latest-24h.json`: 14 rows normalized, 0 dropped (e.g. juejin "Claude Code Harness" row: `2026-05-23T16:24:59Z` → `2026-05-22T17:43:47Z` first_seen)
- [x] Dry-run against `latest-7d.json`: 14 rows normalized, 0 dropped
- [x] Dry-run against `latest-7d-en.json`: 0 hits (HN/RSS upstreams use ISO timestamps correctly — no need to wire normalize there)
- [x] Idempotent re-run: 0 additional rows touched
- [ ] Next cron tick (`refresh-pulse-data.yml`, every 2h) emits clean data with no manual intervention