### PR TITLE
fix: clarify SSE HTML provider errors

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -285,6 +285,8 @@ const en: Translations = {
   'error.noModelSelected': 'No model selected, please select a model first.',
   'error.requestFailed': 'Request failed, please try again.',
   'error.userCancelled': 'Cancelled.',
+  'error.providerReturnedHtml':
+    'The model endpoint returned an HTML page instead of a streaming API response. Check the Base URL, API key, and whether the provider requires a /v1 path or browser login.',
   // 我的AI生涯 / My AI Career
   'page.aiCareer': 'My AI Career',
   'aiCareer.editAvatar': 'Change avatar',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -287,6 +287,12 @@ const en: Translations = {
   'error.userCancelled': 'Cancelled.',
   'error.providerReturnedHtml':
     'The model endpoint returned an HTML page instead of a streaming API response. Check the Base URL, API key, and whether the provider requires a /v1 path or browser login.',
+  'error.providerAuthFailed':
+    'The model provider rejected the API key or account permissions. Check that the API key is correct, active, and allowed to use this model.',
+  'error.providerEndpointInvalid':
+    'The model endpoint could not be found or resolved. Check the Base URL, especially whether the provider requires a /v1 path.',
+  'error.providerRateLimited':
+    'The model provider rejected the request because of rate limits, quota, or billing. Check your plan, balance, and retry later.',
   // 我的AI生涯 / My AI Career
   'page.aiCareer': 'My AI Career',
   'aiCareer.editAvatar': 'Change avatar',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -280,6 +280,12 @@ const ja: Partial<Translations> = {
   'error.userCancelled': 'キャンセルされました。',
   'error.providerReturnedHtml':
     'モデルのエンドポイントがストリーミング API 応答ではなく HTML ページを返しました。Base URL、API キー、/v1 パスの要否、ブラウザログインの有無を確認してください。',
+  'error.providerAuthFailed':
+    'モデルプロバイダーが API キーまたはアカウント権限を拒否しました。API キーが正しく有効で、このモデルを利用できるか確認してください。',
+  'error.providerEndpointInvalid':
+    'モデルのエンドポイントが見つからないか解決できません。Base URL、特に /v1 パスが必要かを確認してください。',
+  'error.providerRateLimited':
+    'レート制限、クォータ、または請求の問題によりモデルプロバイダーがリクエストを拒否しました。プランと残高を確認し、後でもう一度お試しください。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': 'サーバーのハードウェア構成を確認',
   'mother.hintShowSpecsLocal': 'ローカル機のハードウェア構成を確認',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -278,6 +278,8 @@ const ja: Partial<Translations> = {
   'error.noModelSelected': 'モデルが選択されていません。先にモデルを選択してください。',
   'error.requestFailed': 'リクエストに失敗しました。もう一度お試しください。',
   'error.userCancelled': 'キャンセルされました。',
+  'error.providerReturnedHtml':
+    'モデルのエンドポイントがストリーミング API 応答ではなく HTML ページを返しました。Base URL、API キー、/v1 パスの要否、ブラウザログインの有無を確認してください。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': 'サーバーのハードウェア構成を確認',
   'mother.hintShowSpecsLocal': 'ローカル機のハードウェア構成を確認',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -298,6 +298,7 @@ export type TKey =
   | 'error.noModelSelected'
   | 'error.requestFailed'
   | 'error.userCancelled'
+  | 'error.providerReturnedHtml'
   // 我的AI生涯 / My AI Career
   | 'nav.aiCareer'
   | 'page.aiCareer'

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -299,6 +299,9 @@ export type TKey =
   | 'error.requestFailed'
   | 'error.userCancelled'
   | 'error.providerReturnedHtml'
+  | 'error.providerAuthFailed'
+  | 'error.providerEndpointInvalid'
+  | 'error.providerRateLimited'
   // 我的AI生涯 / My AI Career
   | 'nav.aiCareer'
   | 'page.aiCareer'

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -253,6 +253,12 @@ const zhHans: Partial<Translations> = {
   'error.userCancelled': '已取消。',
   'error.providerReturnedHtml':
     '模型接口返回了 HTML 页面，而不是流式 API 响应。请检查 Base URL、API Key，以及该服务是否需要 /v1 路径或网页登录。',
+  'error.providerAuthFailed':
+    '模型服务拒绝了 API Key 或账号权限。请检查 Key 是否正确、未过期，并且有权限使用该模型。',
+  'error.providerEndpointInvalid':
+    '模型接口地址不可用或无法解析。请检查 Base URL，尤其确认该服务是否需要 /v1 路径。',
+  'error.providerRateLimited':
+    '模型服务因限流、额度或计费问题拒绝了请求。请检查套餐、余额，稍后再试。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': '查看服务器的硬件配置',
   'mother.hintShowSpecsLocal': '查看本机的硬件配置',

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -251,6 +251,8 @@ const zhHans: Partial<Translations> = {
   'error.noModelSelected': '未选择模型，请先选择一个模型。',
   'error.requestFailed': '请求失败，请重试。',
   'error.userCancelled': '已取消。',
+  'error.providerReturnedHtml':
+    '模型接口返回了 HTML 页面，而不是流式 API 响应。请检查 Base URL、API Key，以及该服务是否需要 /v1 路径或网页登录。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': '查看服务器的硬件配置',
   'mother.hintShowSpecsLocal': '查看本机的硬件配置',

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -271,6 +271,8 @@ const zhHant: Partial<Translations> = {
   'error.noModelSelected': '未選擇模型，請先選擇一個模型。',
   'error.requestFailed': '請求失敗，請重試。',
   'error.userCancelled': '已取消。',
+  'error.providerReturnedHtml':
+    '模型介面返回了 HTML 頁面，而不是串流 API 回應。請檢查 Base URL、API Key，以及該服務是否需要 /v1 路徑或網頁登入。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': '查看伺服器的硬體配置',
   'mother.hintShowSpecsLocal': '查看本機的硬體配置',

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -273,6 +273,12 @@ const zhHant: Partial<Translations> = {
   'error.userCancelled': '已取消。',
   'error.providerReturnedHtml':
     '模型介面返回了 HTML 頁面，而不是串流 API 回應。請檢查 Base URL、API Key，以及該服務是否需要 /v1 路徑或網頁登入。',
+  'error.providerAuthFailed':
+    '模型服務拒絕了 API Key 或帳號權限。請檢查 Key 是否正確、未過期，並且有權限使用該模型。',
+  'error.providerEndpointInvalid':
+    '模型介面位址不可用或無法解析。請檢查 Base URL，尤其確認該服務是否需要 /v1 路徑。',
+  'error.providerRateLimited':
+    '模型服務因限流、額度或計費問題拒絕了請求。請檢查方案、餘額，稍後再試。',
   'app.name': 'EchoBird',
   'mother.hintShowSpecs': '查看伺服器的硬體配置',
   'mother.hintShowSpecsLocal': '查看本機的硬體配置',

--- a/src/utils/normalizeError.test.ts
+++ b/src/utils/normalizeError.test.ts
@@ -8,7 +8,26 @@ describe('errorToKey', () => {
     ).toBe('error.providerReturnedHtml');
   });
 
-  it('keeps provider errors verbatim when no category matches', () => {
-    expect(errorToKey('Invalid API Key')).toBeNull();
+  it('classifies provider authentication failures', () => {
+    expect(errorToKey('Invalid API Key')).toBe('error.providerAuthFailed');
+    expect(errorToKey('401 Unauthorized')).toBe('error.providerAuthFailed');
   });
-});
+
+  it('classifies provider quota and rate-limit failures', () => {
+    expect(errorToKey('429 Too Many Requests')).toBe('error.providerRateLimited');
+    expect(errorToKey('You exceeded your current quota')).toBe(
+      'error.providerRateLimited'
+    );
+  });
+
+  it('classifies invalid provider endpoint failures', () => {
+    expect(errorToKey('404 Not Found')).toBe('error.providerEndpointInvalid');
+    expect(errorToKey('getaddrinfo ENOTFOUND api.example.com')).toBe(
+      'error.providerEndpointInvalid'
+    );
+  });
+
+  it('keeps unknown provider errors verbatim when no category matches', () => {
+    expect(errorToKey('Provider exploded unexpectedly')).toBeNull();
+  });
+});

--- a/src/utils/normalizeError.test.ts
+++ b/src/utils/normalizeError.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { errorToKey } from './normalizeError';
+
+describe('errorToKey', () => {
+  it('classifies HTML responses rejected during SSE setup', () => {
+    expect(
+      errorToKey('SSE setup error: Invalid header value: "text/html; charset=utf-8"')
+    ).toBe('error.providerReturnedHtml');
+  });
+
+  it('keeps provider errors verbatim when no category matches', () => {
+    expect(errorToKey('Invalid API Key')).toBeNull();
+  });
+});

--- a/src/utils/normalizeError.ts
+++ b/src/utils/normalizeError.ts
@@ -5,14 +5,13 @@ import type { TKey } from '../i18n/types';
  *
  * Returns:
  *   - A TKey when the message matches a known category (timeout, ssh,
- *     cancelled, no-server, no-model, agent-failed). The caller
- *     renders the localized string.
+ *     cancelled, no-server, no-model, agent-failed, or provider setup
+ *     errors). The caller renders the localized string.
  *   - `null` when the message is informative but uncategorized. The
  *     caller renders the message text verbatim, because v4.7.0 made
- *     the backend emit the upstream provider's real error message
- *     ("Invalid API Key" / "Rate limit exceeded" / "You exceeded
- *     your quota") — discarding that into a generic "请求失败" key
- *     would hide the actionable info from the user.
+ *     the backend emit the upstream provider's real error message.
+ *     Discarding unknown provider errors into a generic key would hide
+ *     actionable info from the user.
  *
  * The caller falls back to `error.requestFailed` only when the
  * message is empty (no info to show).
@@ -55,6 +54,49 @@ export function errorToKey(msg: string): TKey | null {
     lower.includes('text/html')
   )
     return 'error.providerReturnedHtml';
+
+  // Common provider configuration/account failures. Keep these narrow so
+  // unknown provider messages still pass through verbatim below.
+  if (
+    lower.includes('401') ||
+    lower.includes('403') ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden') ||
+    lower.includes('authentication') ||
+    lower.includes('auth failed') ||
+    lower.includes('invalid api key') ||
+    lower.includes('invalid_api_key') ||
+    lower.includes('incorrect api key') ||
+    lower.includes('api key is invalid')
+  )
+    return 'error.providerAuthFailed';
+
+  if (
+    lower.includes('429') ||
+    lower.includes('rate limit') ||
+    lower.includes('rate_limit') ||
+    lower.includes('too many requests') ||
+    lower.includes('quota') ||
+    lower.includes('insufficient_quota') ||
+    lower.includes('billing')
+  )
+    return 'error.providerRateLimited';
+
+  if (
+    lower.includes('404') ||
+    lower.includes('invalid url') ||
+    lower.includes('invalid_url') ||
+    lower.includes('unsupported protocol') ||
+    lower.includes('relative url without a base') ||
+    lower.includes('enotfound') ||
+    lower.includes('could not resolve') ||
+    lower.includes('name resolution') ||
+    lower.includes('no such host') ||
+    lower.includes('failed to lookup address') ||
+    (lower.includes('not found') && !lower.includes('model not found'))
+  )
+    return 'error.providerEndpointInvalid';
+
   // SSH / host unreachable / network errors
   if (
     lower.includes('ssh') ||

--- a/src/utils/normalizeError.ts
+++ b/src/utils/normalizeError.ts
@@ -46,6 +46,15 @@ export function errorToKey(msg: string): TKey | null {
   )
     return 'error.connectionTimeout';
 
+  // The streaming client expects text/event-stream. Some OpenAI-compatible
+  // relays return an HTML error/login page instead, which bubbles up as a
+  // low-level SSE header error.
+  if (
+    lower.includes('sse setup error') &&
+    lower.includes('invalid header value') &&
+    lower.includes('text/html')
+  )
+    return 'error.providerReturnedHtml';
   // SSH / host unreachable / network errors
   if (
     lower.includes('ssh') ||


### PR DESCRIPTION
﻿## Summary
- classify the SSE setup error caused by HTML responses from OpenAI-compatible providers
- classify common provider setup failures for invalid API keys, invalid endpoints, and quota/rate-limit errors
- show localized, actionable messages that point users to Base URL, API key, `/v1`, account permission, quota, or billing checks
- add Vitest coverage for the new error mappings while preserving pass-through for unknown provider errors

## Root Cause
When Mother Agent streams from an OpenAI-compatible endpoint, some relays return an HTML page instead of a `text/event-stream` response. The backend currently bubbles that up as:

`SSE setup error: Invalid header value: "text/html; charset=utf-8"`

Other common provider configuration failures, such as `Invalid API Key`, `401 Unauthorized`, `429 Too Many Requests`, or `404 Not Found`, can also be surfaced as raw provider text. Those messages are actionable, but users benefit from a localized hint that separates key/account problems from endpoint and quota problems.

## Test Plan
- `npm.cmd test -- --run src/utils/normalizeError.test.ts` -> 5 tests passed
- `npm.cmd run typecheck` -> passed
- `npm.cmd run lint` -> passed with existing warnings only (42 warnings, 0 errors)
