### PR TITLE
fix: focus Mother Agent prefilled input

### DIFF
--- a/src/pages/MotherAgent/MotherAgentMain.tsx
+++ b/src/pages/MotherAgent/MotherAgentMain.tsx
@@ -27,6 +27,7 @@ export function MotherAgentMain() {
     agentModelData: _agentModelData,
     agentState: _agentState,
     chatEndRef,
+    chatInputRef,
     handleChatSend,
     sendMessage,
 
@@ -72,7 +73,6 @@ export function MotherAgentMain() {
   }, [clearChat]);
 
   const [_serverModel, setServerModel] = useState<string | null>(null);
-  const chatInputRef = useRef<HTMLTextAreaElement>(null!);
   const _fileInputRef = useRef<HTMLInputElement>(null!);
   const _imageInputRef = useRef<HTMLInputElement>(null!);
 

--- a/src/pages/MotherAgent/MotherAgentProvider.tsx
+++ b/src/pages/MotherAgent/MotherAgentProvider.tsx
@@ -17,7 +17,7 @@ import { useNavigationStore } from '../../stores/navigationStore';
 export function MotherAgentProvider({ children }: { children: React.ReactNode }) {
   // From stores (replaces drilled props)
   const { detectedTools: _detectedTools } = useToolsStore();
-  const { motherPrefill: initialMessage } = useNavigationStore();
+  const { activePage, motherPrefill: initialMessage } = useNavigationStore();
   const onAgentRunningChange = useNavigationStore((s) => s.setAgentRunning);
   const { t: _t, locale } = useI18n(); // locale for agent hint; t for error messages
   const [models, setModels] = useState<ModelConfig[]>([]);
@@ -65,15 +65,16 @@ export function MotherAgentProvider({ children }: { children: React.ReactNode })
   const [chatInputFocused, setChatInputFocused] = useState(false);
   const [chatCursorPos, setChatCursorPos] = useState(0);
   const chatEndRef = useRef<HTMLDivElement>(null!);
-  const chatInputRef = useRef<HTMLInputElement>(null!);
+  const chatInputRef = useRef<HTMLTextAreaElement>(null!);
   const abortTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!initialMessage) return;
+    if (!initialMessage || activePage !== 'mother') return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setChatInput(initialMessage);
-    setTimeout(() => chatInputRef.current?.focus(), 100);
-  }, [initialMessage]);
+    const id = setTimeout(() => chatInputRef.current?.focus(), 100);
+    return () => clearTimeout(id);
+  }, [activePage, initialMessage]);
 
   // SSH servers shared state (persisted via backend)
   const [sshServers, setSSHServers] = useState<

--- a/src/pages/MotherAgent/types.ts
+++ b/src/pages/MotherAgent/types.ts
@@ -43,7 +43,7 @@ export interface MotherAgentCtx {
   setChatInputFocused: (v: boolean) => void;
   chatCursorPos: number;
   setChatCursorPos: (v: number) => void;
-  chatInputRef: React.RefObject<HTMLInputElement>;
+  chatInputRef: React.RefObject<HTMLTextAreaElement>;
   chatEndRef: React.RefObject<HTMLDivElement>;
   handleChatSend: () => void;
   sendMessage: (msg: string, displayText?: string, chips?: BubbleChip[]) => void;


### PR DESCRIPTION
﻿## Summary
- wire the Mother Agent context input ref to the actual textarea
- rerun the prefill/focus effect when navigation enters Mother Agent, even if the prefill text is unchanged
- align the context ref type with the textarea element used by the chat composer

## Why
Navigation helpers such as app install prompts call `goToMother(prefill)`. The provider sets the prefilled text and calls `chatInputRef.current?.focus()`, but the rendered textarea used a separate local ref in `MotherAgentMain`, so the focus call had no target. Also, repeated navigation with the same prefill string would not retrigger the effect unless page activation was included.

## Test Plan
- `npm.cmd run typecheck`
- `npm.cmd run lint` (exits 0; existing warnings only)
