### PR TITLE
feat: one-click duplicate for Model Center configs

### DIFF
--- a/src/components/cards/ModelCard.test.tsx
+++ b/src/components/cards/ModelCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { TKey } from '../../i18n/types';
+import { getModelIcon } from './ModelCard';
+import { en } from '../../i18n/en';
+import zhHans from '../../i18n/zh-Hans';
+import zhHant from '../../i18n/zh-Hant';
+import ja from '../../i18n/ja';
+
+// The Model Center "duplicate config" action (issue #337) renders a
+// [btn.duplicate] button. These tests pin the i18n contract for that key and
+// the icon-resolution helper the card relies on.
+
+describe('btn.duplicate i18n key', () => {
+  // Forcing the union member here makes `tsc --noEmit` fail if the key was
+  // ever dropped from TKey, so the type and the dictionaries stay in lockstep.
+  const key: TKey = 'btn.duplicate';
+
+  it('resolves to a non-empty string in every locale (no missing-key fallback)', () => {
+    for (const [locale, dict] of [
+      ['en', en],
+      ['zh-Hans', zhHans],
+      ['zh-Hant', zhHant],
+      ['ja', ja],
+    ] as const) {
+      const value = dict[key];
+      expect(value, `missing btn.duplicate in ${locale}`).toBeTruthy();
+      expect(typeof value).toBe('string');
+      expect(String(value).trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getModelIcon', () => {
+  it('matches a provider keyword to its icon asset', () => {
+    expect(getModelIcon('Claude Sonnet', 'claude-3-5-sonnet')).toBe('./icons/models/claude.svg');
+    expect(getModelIcon('My GPT', 'gpt-4o')).toBe('./icons/models/chatgpt.svg');
+  });
+
+  it('returns null when no keyword matches', () => {
+    expect(getModelIcon('totally-unknown-model', 'xyz-001')).toBeNull();
+  });
+});

--- a/src/components/cards/ModelCard.tsx
+++ b/src/components/cards/ModelCard.tsx
@@ -85,6 +85,7 @@ export interface ModelCardProps {
   onClick?: () => void;
   onEdit?: () => void; // edit callback
   onDelete?: () => void; // delete callback
+  onDuplicate?: () => void; // duplicate callback — seeds Add-Model modal from this config
   onProtocolClick?: (protocol: 'openai' | 'anthropic') => void; // protocol tag click
 }
 
@@ -183,6 +184,7 @@ export const ModelCard = React.memo(
     onClick,
     onEdit,
     onDelete,
+    onDuplicate,
     onProtocolClick: _onProtocolClick,
   }: ModelCardProps & { isActive?: boolean }) => {
     const iconPath = getModelIcon(name, modelId);
@@ -199,7 +201,7 @@ export const ModelCard = React.memo(
         onClick={onClick}
       >
         {/* Action buttons — top right */}
-        {(onEdit || onDelete) && (
+        {(onEdit || onDelete || onDuplicate) && (
           <div className="absolute top-2 right-2 flex gap-1.5">
             {onDelete && (
               <button
@@ -219,6 +221,17 @@ export const ModelCard = React.memo(
                 }}
               >
                 [{t('btn.delete')}]
+              </button>
+            )}
+            {onDuplicate && (
+              <button
+                className="text-xs font-mono text-cyber-text-muted/70 hover:text-cyber-text transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDuplicate();
+                }}
+              >
+                [{t('btn.duplicate')}]
               </button>
             )}
             {onEdit && (

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -96,6 +96,7 @@ const en: Translations = {
   'btn.cancel': 'CANCEL',
   'btn.delete': 'DELETE',
   'btn.edit': 'EDIT',
+  'btn.duplicate': 'DUPLICATE',
   'btn.launchApp': 'LAUNCH APP',
   'btn.modifyOnly': 'MODIFY ONLY',
   'btn.start': 'START',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -109,6 +109,7 @@ const ja: Partial<Translations> = {
   'btn.cancel': 'キャンセル',
   'btn.delete': '削除',
   'btn.edit': '編集',
+  'btn.duplicate': '複製',
   'btn.launchApp': 'アプリを起動',
   'btn.modifyOnly': '変更のみ',
   'btn.start': '起動',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -93,6 +93,7 @@ export type TKey =
   | 'btn.cancel'
   | 'btn.delete'
   | 'btn.edit'
+  | 'btn.duplicate'
   | 'btn.launchApp'
   | 'btn.modifyOnly'
   | 'btn.start'

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -85,6 +85,7 @@ const zhHans: Partial<Translations> = {
   'btn.cancel': '取消',
   'btn.delete': '删除',
   'btn.edit': '编辑',
+  'btn.duplicate': '复制',
   'btn.launchApp': '启动应用',
   'btn.modifyOnly': '仅修改',
   'btn.start': '启动',

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -105,6 +105,7 @@ const zhHant: Partial<Translations> = {
   'btn.cancel': '取消',
   'btn.delete': '刪除',
   'btn.edit': '編輯',
+  'btn.duplicate': '複製',
   'btn.launchApp': '啟動應用',
   'btn.modifyOnly': '僅修改',
   'btn.start': '啟動',

--- a/src/pages/ModelNexus/ModelNexus.tsx
+++ b/src/pages/ModelNexus/ModelNexus.tsx
@@ -400,6 +400,49 @@ export function ModelNexusMain() {
     [setUserModels]
   );
 
+  const handleCardDuplicate = useCallback(
+    async (model: (typeof userModels)[0]) => {
+      // Reload fresh model data from disk first: ModelCard is memoized with a
+      // comparator that skips function props and never compares apiKey, so the
+      // duplicate callback can close over a stale model whose key was since
+      // rotated/encrypted. Mirror handleCardEdit so we seed the latest secret.
+      let freshModel = model;
+      try {
+        const freshModels = await api.getModels();
+        const found = freshModels.find((m) => m.internalId === model.internalId);
+        if (found) {
+          freshModel = found;
+          setUserModels(freshModels);
+        }
+      } catch {
+        /* fallback to stale model */
+      }
+
+      // Seed the Add-Model modal from the source config so the user only edits
+      // the name and model id. editingModelId stays null → the modal's Save
+      // branch calls api.addModel and creates a brand-new config (not update).
+      setEditingModelId(null);
+      // Mirror handleCardEdit: if the source key is an enc:v1: secret that has
+      // self-destructed after an environment change, flag it so the modal shows
+      // the destroyed state and the user re-enters it instead of saving a copy
+      // with unusable ciphertext.
+      if (freshModel.apiKey?.startsWith('enc:v1:') && api.isKeyDestroyed) {
+        api.isKeyDestroyed(freshModel.internalId).then((destroyed) => setKeyDestroyed(destroyed));
+      } else {
+        setKeyDestroyed(false);
+      }
+      setNewModelForm({
+        name: freshModel.name ? `${freshModel.name} copy` : '',
+        baseUrl: freshModel.baseUrl,
+        anthropicUrl: freshModel.anthropicUrl || '',
+        apiKey: freshModel.apiKey,
+        modelId: freshModel.modelId || '',
+      });
+      setShowAddModelModal(true);
+    },
+    [setEditingModelId, setKeyDestroyed, setNewModelForm, setShowAddModelModal, setUserModels]
+  );
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
@@ -438,6 +481,7 @@ export function ModelNexusMain() {
                   onClick={() => handleCardClick(model)}
                   onProtocolClick={(protocol) => handleCardProtocolClick(model, protocol)}
                   onEdit={isDemo ? undefined : () => handleCardEdit(model)}
+                  onDuplicate={isDemo ? undefined : () => handleCardDuplicate(model)}
                   onDelete={isDemo ? undefined : () => handleCardDelete(model.internalId)}
                 />
               );


### PR DESCRIPTION
## Summary

Adds a one-click duplicate action to each card in the Model Center, addressing #337. The reporter noted that configuring several models under the same provider is tedious because the base URL and API key are identical and only the model id changes; the repo owner (edison7009) reframed the ask as a "copy this config" feature, which the reporter confirmed.

This implements exactly that: a `[DUPLICATE]` button sits next to the existing Edit/Delete actions on every model card. Clicking it opens the existing Add-Model modal pre-filled from the source config (same base URL, Anthropic URL, API key, and model id, with the name suffixed `copy`), so the user only has to change the name and model id before saving.

## Why this matters

Users who run many models behind a single provider currently re-type the same base URL and API key for every variant. Duplicating an existing config removes that repetition and the associated copy-paste errors, while keeping each model as its own independent entry.

The change is intentionally frontend-only and reuses the existing `add_model` command: because `editingModelId` stays `null`, the modal's Save branch calls `api.addModel(...)` and creates a brand-new config rather than updating the source. No new backend command is introduced. The duplicate handler mirrors the Edit path's fresh-reload and destroyed-key handling so a copied `enc:v1:` key reflects its current state instead of a stale closure.

## Testing

- `npm run typecheck` (tsc --noEmit) - clean
- `npm test` (vitest) - all pass, including new `src/components/cards/ModelCard.test.tsx` covering the new `btn.duplicate` key across all four locales and the card's icon helper
- `npm run lint` - 0 errors
- `npm run format:check` on changed files - clean

Fixes #337
